### PR TITLE
Add output type annotation to `VectorStoreManager.connect`.

### DIFF
--- a/uncertainty_engine_types/vector_store.py
+++ b/uncertainty_engine_types/vector_store.py
@@ -114,7 +114,7 @@ class VectorStoreManager(BaseModel):
     embedding_api_key: str
 
     @typechecked
-    def connect(self):
+    def connect(self) -> WeaviateVectorStoreConnection:
         """
         Connect to the vector store.
 


### PR DESCRIPTION
Prevents `typeguard` warning: `UserWarning: no type annotations present -- not typechecking uncertainty_engine_types.vector_store.VectorStoreManager.connect warn('no type annotations present -- not typechecking {}'.format(function_name(func)))`