### PR TITLE
Drop pandas version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -507,8 +507,8 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">=1.22.4", markers = "python_version < \"3.11\""},
-    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
     {version = ">=1.23.2", markers = "python_version == \"3.11\""},
+    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -767,8 +767,8 @@ astroid = ">=3.3.8,<=3.4.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
     {version = ">=0.2", markers = "python_version < \"3.11\""},
-    {version = ">=0.3.7", markers = "python_version >= \"3.12\""},
     {version = ">=0.3.6", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
+    {version = ">=0.3.7", markers = "python_version >= \"3.12\""},
 ]
 isort = ">=4.2.5,<5.13.0 || >5.13.0,<7"
 mccabe = ">=0.6,<0.8"
@@ -1007,4 +1007,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "d5ef3bb3acae14657f26873f1c3d90769a26c1a11f46a29bada133750fab04ff"
+content-hash = "2e6f84ff04a01ca2d5bce25e5c39b6a227aa4fd45a24a0f9b4d3431148a68f6e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 readme = "README.md"
 
 [tool.poetry.dependencies]
-pandas = "^2.2.3"
+pandas = "^2.2.2"
 pydantic = "^2.10.5"
 python = ">=3.10,<4.0"
 typeguard = ">=2.13.3,<2.14.0"


### PR DESCRIPTION
This PR drops the `pandas` version in the `.toml` file to `^2.2.2`. This is done to be compatible with the Google Colab environment, as of writing, which is fixed at `2.2.2`.