### PR TITLE
Typing message.user as Literal

### DIFF
--- a/uncertainty_engine_types/__init__.py
+++ b/uncertainty_engine_types/__init__.py
@@ -3,7 +3,7 @@ from .execution_error import ExecutionError
 from .graph import Graph, NodeElement, NodeId, SourceHandle, TargetHandle
 from .handle import Handle
 from .llm import LLM, LLMConfig, LLMProvider, OpenAILLM, OllamaLLM
-from .message import Message, StructuredOutput
+from .message import Message, StructuredOutput, StructuredOutputValue
 from .model import TwinLabModel, save_model
 from .node_info import NodeInfo, NodeInputInfo, NodeOutputInfo
 from .sensor_designer import SensorDesigner, save_sensor_designer
@@ -37,6 +37,7 @@ __all__ = [
     "SQLKind",
     "SQLManager",
     "StructuredOutput",
+    "StructuredOutputValue",
     "TabularData",
     "TargetHandle",
     "Token",

--- a/uncertainty_engine_types/__init__.py
+++ b/uncertainty_engine_types/__init__.py
@@ -3,7 +3,7 @@ from .execution_error import ExecutionError
 from .graph import Graph, NodeElement, NodeId, SourceHandle, TargetHandle
 from .handle import Handle
 from .llm import LLM, LLMConfig, LLMProvider, OpenAILLM, OllamaLLM
-from .message import Message
+from .message import Message, StructuredOutput
 from .model import TwinLabModel, save_model
 from .node_info import NodeInfo, NodeInputInfo, NodeOutputInfo
 from .sensor_designer import SensorDesigner, save_sensor_designer
@@ -36,6 +36,7 @@ __all__ = [
     "SQLDatabase",
     "SQLKind",
     "SQLManager",
+    "StructuredOutput",
     "TabularData",
     "TargetHandle",
     "Token",

--- a/uncertainty_engine_types/message.py
+++ b/uncertainty_engine_types/message.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict, Sequence, Union
+from typing import Dict, Literal, Sequence, Union
 
 from pydantic import BaseModel
 
@@ -8,6 +8,6 @@ Value = Union[str, float, int]
 
 
 class Message(BaseModel):
-    role: str
+    role: Literal["system", "user", "assistant"]
     content: Union[str, Dict[str, Union[Value, Sequence[Value]]]]
     timestamp: datetime

--- a/uncertainty_engine_types/message.py
+++ b/uncertainty_engine_types/message.py
@@ -10,6 +10,6 @@ StructuredOutput = dict[str, StructuredOutputValue]
 
 
 class Message(BaseModel):
-    role: Literal["system", "user", "assistant"]
+    role: Literal["instruction", "user", "engine"]
     content: StructuredOutput
     timestamp: datetime

--- a/uncertainty_engine_types/message.py
+++ b/uncertainty_engine_types/message.py
@@ -5,7 +5,8 @@ from pydantic import BaseModel
 
 
 Value = str | float | int
-StructuredOutput = dict[str, Value | Sequence[Value]]
+StructuredOutputValue = Value | Sequence[Value]
+StructuredOutput = dict[str, StructuredOutputValue]
 
 
 class Message(BaseModel):

--- a/uncertainty_engine_types/message.py
+++ b/uncertainty_engine_types/message.py
@@ -4,10 +4,11 @@ from typing import Dict, Literal, Sequence, Union
 from pydantic import BaseModel
 
 
-Value = Union[str, float, int]
+Value = str | float | int
+StructuredOutput = dict[str, Value | Sequence[Value]]
 
 
 class Message(BaseModel):
     role: Literal["system", "user", "assistant"]
-    content: Union[str, Dict[str, Union[Value, Sequence[Value]]]]
+    content: StructuredOutput
     timestamp: datetime


### PR DESCRIPTION
Adding the set of model-compatible users for LLMs.

This can be extended in future, but we'll need to build a mapping into the Run LLM node to target on one of
```
['system', 'user', 'assistant]
```
for any new user we introduce.
