### PR TITLE
Added load_balancer_url to NodeInfo

### DIFF
--- a/uncertainty_engine_types/node_info.py
+++ b/uncertainty_engine_types/node_info.py
@@ -36,6 +36,7 @@ class NodeInfo(BaseModel):
     cost: int
     inputs: dict[str, NodeInputInfo]
     outputs: dict[str, NodeOutputInfo] = {}
+    load_balancer_url: Optional[str] = None
     queue_url: Optional[str] = None
     cache_url: Optional[str] = None
     versions: Versions


### PR DESCRIPTION
Required for the CoreAPI to know where nodes are located