### PR TITLE
Rename `Conversation` to `ChatHistory`

### DIFF
--- a/uncertainty_engine_types/__init__.py
+++ b/uncertainty_engine_types/__init__.py
@@ -1,6 +1,6 @@
 from . import utils
 from .context import Context
-from .conversation import Conversation
+from .chat_history import ChatHistory
 from .dataset import CSVDataset
 from .embeddings import TextEmbeddingsConfig, TextEmbeddingsProvider
 from .execution_error import ExecutionError
@@ -32,8 +32,8 @@ from .version import __version__
 
 __all__ = [
     "__version__",
+    "ChatHistory",
     "Context",
-    "Conversation",
     "CSVDataset",
     "Document",
     "ExecutionError",

--- a/uncertainty_engine_types/__init__.py
+++ b/uncertainty_engine_types/__init__.py
@@ -1,6 +1,6 @@
 from . import utils
-from .context import Context
 from .chat_history import ChatHistory
+from .context import Context
 from .dataset import CSVDataset
 from .embeddings import TextEmbeddingsConfig, TextEmbeddingsProvider
 from .execution_error import ExecutionError

--- a/uncertainty_engine_types/chat_history.py
+++ b/uncertainty_engine_types/chat_history.py
@@ -3,5 +3,5 @@ from pydantic import BaseModel
 from .message import Message
 
 
-class Conversation(BaseModel):
+class ChatHistory(BaseModel):
     messages: list[Message]

--- a/uncertainty_engine_types/message.py
+++ b/uncertainty_engine_types/message.py
@@ -1,10 +1,10 @@
 from datetime import datetime
-from typing import Any, Literal
+from typing import Literal
 
 from pydantic import BaseModel
 
 
 class Message(BaseModel):
     role: Literal["instruction", "user", "engine"]
-    content: dict[str, Any]
+    content: str
     timestamp: datetime


### PR DESCRIPTION
This PR renames `Conversation` to `ChatHistory`. Additionally, the type of `Message.content` has been changed to `str`.