### PR TITLE
`PB-273`: CI

### DIFF
--- a/.github/workflows/linting_formatting.yaml
+++ b/.github/workflows/linting_formatting.yaml
@@ -1,0 +1,40 @@
+name: Run linter and formatter
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+
+jobs:
+  linting_formatting:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install poetry
+        run: pipx install poetry
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "poetry"
+
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Run linter
+        run: sh ci/run_linter.sh
+
+      - name: Run formatter
+        run: sh ci/run_formatter.sh

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -1,0 +1,37 @@
+name: Run tests
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+
+jobs:
+  unit_tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install poetry
+        run: pipx install poetry
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "poetry"
+
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Run tests
+        run: sh ci/run_tests.sh

--- a/ci/run_linter.sh
+++ b/ci/run_linter.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 set -e
 
-poetry run flake8 uncertainty_engine_types
+# When using flake8 we ignore:
+# E501: Line too long: Too strict for us
+# W503: Line break before binary operator: The advice is changing to the opposite here soon (W504), so no point. See: https://www.flake8rules.com/rules/W503.html.
+# For tests we ignore:
+# F401: When testing imports, we don't need to use the imported module
+poetry run flake8 --ignore=E501,W503 --per-file-ignores="tests/test_library_import.py:F401" uncertainty_engine_types tests

--- a/ci/setup_hooks.sh
+++ b/ci/setup_hooks.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Define the top-level directory of the repository and the Git directory
+REPO_TOPLEVEL=$(git rev-parse --show-toplevel)
+GIT_DIR=$(git rev-parse --git-dir)
+
+# Define the source and target directories for the hooks
+REPO_HOOKS_DIR="$REPO_TOPLEVEL/git_hooks"
+GIT_HOOKS_DIR="$GIT_DIR/hooks"
+
+# Ensure the commands run successfully before proceeding
+if [ -z "$REPO_HOOKS_DIR" ] || [ -z "$GIT_HOOKS_DIR" ]; then
+    echo "Error: Could not determine repository or hooks directory."
+    exit 1
+fi
+
+# Link each script from the git_hooks directory to the .git/hooks directory and make them executable
+for hook in "$REPO_HOOKS_DIR"/*; do
+    if [ -f "$hook" ]; then
+        hook_name=$(basename "$hook")
+        ln -sf "$hook" "$GIT_HOOKS_DIR/$hook_name"  # Force symlink creation
+        chmod +x "$GIT_HOOKS_DIR/$hook_name"  # Make the script executable
+        echo "Linked and set executable: $hook_name"
+    else
+        echo "Skipping non-file item: $hook"
+    fi
+done
+
+echo "Git hooks set up successfully."

--- a/git_hooks/pre-push
+++ b/git_hooks/pre-push
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+echo "Running continous integration..."
+
+echo "[1/3] Running code formatter..."
+sh ./ci/run_formatter.sh
+
+echo "[2/3] Running linter..."
+sh ./ci/run_linter.sh
+
+echo "[3/3] Running unit tests..."
+sh ./ci/run_tests.sh

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -241,7 +241,7 @@ def job_info_data() -> dict:
     """
 
     return {
-        "status": JobStatus.COMPLETED.value,
+        "status": JobStatus.COMPLETED,
         "message": "message",
         "inputs": {"input_1": "input_1"},
         "outputs": {"output_1": "output_1"},

--- a/tests/test_handle.py
+++ b/tests/test_handle.py
@@ -9,7 +9,7 @@ def test_handle(handle_data: dict):
     """
 
     # Define some arbitrary handle string
-    handle_str = f"{handle_data["node_name"]}.{handle_data["node_handle"]}"
+    handle_str = f"{handle_data['node_name']}.{handle_data['node_handle']}"
 
     # Create a Handle object from the handle string
     handle = Handle(handle_str)

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import pytest
 from pydantic import ValidationError
 

--- a/uncertainty_engine_types/embeddings.py
+++ b/uncertainty_engine_types/embeddings.py
@@ -23,7 +23,9 @@ class TextEmbeddingsConfig(BaseModel):
     @classmethod
     def check_provider(cls, values):
         provider = values.get("provider")
-        if provider == TextEmbeddingsProvider.OLLAMA.value and not values.get("ollama_url"):
+        if provider == TextEmbeddingsProvider.OLLAMA.value and not values.get(
+            "ollama_url"
+        ):
             raise ValueError("ollama_url must be provided for 'ollama' provider.")
         if provider == TextEmbeddingsProvider.OPENAI.value and not values.get(
             "openai_api_key"

--- a/uncertainty_engine_types/embeddings.py
+++ b/uncertainty_engine_types/embeddings.py
@@ -1,10 +1,10 @@
-from enum import StrEnum
+from enum import Enum
 from typing import Optional
 
 from pydantic import BaseModel, model_validator
 
 
-class TextEmbeddingsProvider(StrEnum):
+class TextEmbeddingsProvider(Enum):
     OPENAI = "openai"
     OLLAMA = "ollama"
 
@@ -23,9 +23,9 @@ class TextEmbeddingsConfig(BaseModel):
     @classmethod
     def check_provider(cls, values):
         provider = values.get("provider")
-        if provider == TextEmbeddingsProvider.OLLAMA and not values.get("ollama_url"):
+        if provider == TextEmbeddingsProvider.OLLAMA.value and not values.get("ollama_url"):
             raise ValueError("ollama_url must be provided for 'ollama' provider.")
-        if provider == TextEmbeddingsProvider.OPENAI and not values.get(
+        if provider == TextEmbeddingsProvider.OPENAI.value and not values.get(
             "openai_api_key"
         ):
             raise ValueError("openai_api_key must be provided for 'openai' provider.")

--- a/uncertainty_engine_types/job.py
+++ b/uncertainty_engine_types/job.py
@@ -1,10 +1,10 @@
-from enum import StrEnum
+from enum import Enum
 from typing import Optional
 
 from pydantic import BaseModel
 
 
-class JobStatus(StrEnum):
+class JobStatus(Enum):
     PENDING = "pending"
     RUNNING = "running"
     COMPLETED = "completed"

--- a/uncertainty_engine_types/llm.py
+++ b/uncertainty_engine_types/llm.py
@@ -1,10 +1,10 @@
-from enum import StrEnum
+from enum import Enum
 from typing import Optional
 
 from pydantic import BaseModel, model_validator
 
 
-class LLMProvider(StrEnum):
+class LLMProvider(Enum):
     OPENAI = "openai"
     OLLAMA = "ollama"
 
@@ -24,8 +24,8 @@ class LLMConfig(BaseModel):
     @classmethod
     def check_provider(cls, values):
         provider = values.get("provider")
-        if provider == LLMProvider.OLLAMA and not values.get("ollama_url"):
+        if provider == LLMProvider.OLLAMA.value and not values.get("ollama_url"):
             raise ValueError("ollama_url must be provided for 'ollama' provider.")
-        if provider == LLMProvider.OPENAI and not values.get("openai_api_key"):
+        if provider == LLMProvider.OPENAI.value and not values.get("openai_api_key"):
             raise ValueError("openai_api_key must be provided for 'openai' provider.")
         return values


### PR DESCRIPTION
This PR adds some CI bits. Action workflows have been added to run the tests, formatter, and linter on PR or push to `dev` or `main`.

This PR also adds some minor updates to the `run_linter.sh` CI script so that some rules are ignored:
- E501: Line too long: Too strict for us.
- W503: Line break before binary operator: The advice is changing to the opposite here soon (W504), so no point. See: https://www.flake8rules.com/rules/W503.html.
- F401: When testing imports, we don't need to use the imported module (**only ignore for a single test file**).

Finally a pre-push hook setup has been added.