### PR TITLE
Add Mesh type using in create mesh node

### DIFF
--- a/uncertainty_engine_types/file.py
+++ b/uncertainty_engine_types/file.py
@@ -1,6 +1,7 @@
-from typing import Union
+from typing import Union, List, Tuple, Dict
+from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, model_validator
 
 
 class S3Storage(BaseModel):
@@ -28,7 +29,40 @@ class Image(File):
 
 
 class Mesh(File):
+    """
+    Model representing a mesh with nodes, elements, and associated data
+    Includes metadata about the mesh and its storage location
+    """
+    DataType = Union[List[float], List[List[float]]]  # Scalars or Vectors
+
+    # Metadata
+    created_by: str
+    project_id: str
+    date_created: datetime = Field(default_factory=datetime.now)
+    last_edited: datetime = Field(default_factory=datetime.now)
+    name: str
+    version: str
+    
+    # Mesh data
+    nodes: List[List[float]] = Field(default_factory=list)  # 3D coordinates of nodes
+    elements: List[Tuple[str, List[List[int]]]] = Field(default_factory=list)  # Elements with type and connectivity
+    node_data: Dict[str, DataType] = Field(default_factory=dict)  # Additional data associated with nodes
+    element_data: Dict[str, List[List[List[int]]]] = Field(default_factory=dict)  # Additional data associated with elements
+    
+    # Storage info
     location: FileLocation
+    
+    # Element properties
+    element_type: str
+    nel: int = 0  # Number of elements (computed)
+    nnodes: int = 0  # Number of nodes (computed)
+
+    @model_validator(mode="after")
+    def compute_derived_fields(self):
+        """Automatically calculate number of elements and nodes after model initialization"""
+        self.nel = len(self.elements)
+        self.nnodes = len(self.nodes)
+        return self
 
 
 class PDF(File):


### PR DESCRIPTION
This pull request implements the pydantic implementation of a Mesh object in the uncertainty engine.

Effects no other components.