### PR TITLE
Removing ttr from model config

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -340,7 +340,6 @@ def model_config_data() -> dict:
     """
 
     return {
-        "train_test_ratio": 0.8,
         "input_variance": 0.1,
         "output_variance": 0.1,
         "model_type": "SingleTaskGPTorch",

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -23,7 +23,6 @@ def test_model_config(model_config_data: dict):
 @pytest.mark.parametrize(
     "field, expected",
     [
-        ("train_test_ratio", 1.0),
         ("input_variance", None),
         ("output_variance", None),
         ("model_type", "SingleTaskGPTorch"),
@@ -53,7 +52,6 @@ def test_model_config_optional(
 @pytest.mark.parametrize(
     "field, invalid",
     [
-        ("train_test_ratio", "invalid"),
         ("input_variance", "invalid"),
         ("output_variance", "invalid"),
         ("model_type", 0.0),

--- a/uncertainty_engine_types/model_config.py
+++ b/uncertainty_engine_types/model_config.py
@@ -4,7 +4,6 @@ from pydantic import BaseModel
 
 
 class ModelConfig(BaseModel):
-    train_test_ratio: float = 1.0
     input_variance: Optional[float] = None
     output_variance: Optional[float] = None
     model_type: Literal["SingleTaskGPTorch"] = "SingleTaskGPTorch"


### PR DESCRIPTION
twinLab models do not take train_test_ratio as a parameter so removing it from the config.