### PR TITLE
Add NodeRequirementsInfo subtype to NodeInfo

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,7 @@ def context_data(node_info_data: dict) -> dict:
         "queue_url": "queue_url",
         "cache_url": "cache_url",
         "nodes": {"node_1": node_info_data},
+        "timeout": 60,
         "user": {
             "email": "mr.pinecones@digilab.ai",
             "project_id": "9hd239n8nd7923j08j",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,11 @@ def context_data(node_info_data: dict) -> dict:
         "queue_url": "queue_url",
         "cache_url": "cache_url",
         "nodes": {"node_1": node_info_data},
+        "user": {
+            "email": "mr.pinecones@digilab.ai",
+            "project_id": "9hd239n8nd7923j08j",
+            "cost_code": "This is a cost code",
+        },
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,7 +91,6 @@ def context_data(node_info_data: dict) -> dict:
         "job_id": "job_id",
         "queue_url": "queue_url",
         "cache_url": "cache_url",
-        "timeout": 60,
         "nodes": {"node_1": node_info_data},
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,7 @@ def node_info_data(
         "cost": 10,
         "inputs": {"input_1": node_input_info_data},
         "outputs": {"output_1": node_output_info_data},
+        "requirements": {"cpu": 256, "gpu": True, "memory": 512, "timeout": 60},
         "load_balancer_url": "load_balancer_url",
         "queue_url": "queue_url",
         "cache_url": "cache_url",

--- a/uncertainty_engine_types/__init__.py
+++ b/uncertainty_engine_types/__init__.py
@@ -59,6 +59,7 @@ __all__ = [
     "NodeInfo",
     "NodeInputInfo",
     "NodeOutputInfo",
+    "NodeRequirementsInfo",
     "PDF",
     "Prompt",
     "ResourceID",

--- a/uncertainty_engine_types/node_info.py
+++ b/uncertainty_engine_types/node_info.py
@@ -20,6 +20,13 @@ class NodeOutputInfo(BaseModel):
     description: str
 
 
+class NodeRequirementsInfo(BaseModel):
+    cpu: int
+    gpu: int
+    memory: int
+    timeout: int
+
+
 class NodeInfo(BaseModel):
     id: str
     label: str
@@ -30,6 +37,7 @@ class NodeInfo(BaseModel):
     cost: int
     inputs: dict[str, NodeInputInfo]
     outputs: dict[str, NodeOutputInfo] = {}
+    requirements: NodeRequirementsInfo
     load_balancer_url: Optional[str] = None
     queue_url: Optional[str] = None
     cache_url: Optional[str] = None

--- a/uncertainty_engine_types/node_info.py
+++ b/uncertainty_engine_types/node_info.py
@@ -22,7 +22,7 @@ class NodeOutputInfo(BaseModel):
 
 class NodeRequirementsInfo(BaseModel):
     cpu: int
-    gpu: int
+    gpu: bool
     memory: int
     timeout: int
 


### PR DESCRIPTION
To correctly pass the timeout information to the `create_context` function in the base image we need to capture the information in the `NodeInfo` class:


```python
class NodeRequirementsInfo(BaseModel):
    cpu: int
    gpu: int
    memory: int
    timeout: int


class NodeInfo(BaseModel):
    id: str
    label: str
    category: str
    description: str
    long_description: str
    image_name: str
    cost: int
    inputs: dict[str, NodeInputInfo]
    outputs: dict[str, NodeOutputInfo] = {}
    requirements: NodeRequirementsInfo
    load_balancer_url: Optional[str] = None
    queue_url: Optional[str] = None
    cache_url: Optional[str] = None
    version_types_lib: str = __version__
    version_base_image: int
    version_node: int
```