### PR TITLE
Make NodeInfo.requirements optional

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,10 @@
 from datetime import datetime
+from typing import Any
 
 import pytest
 from pytest import FixtureRequest
 
-from uncertainty_engine_types import TextEmbeddingsProvider, JobStatus, SQLKind
+from uncertainty_engine_types import JobStatus, SQLKind, TextEmbeddingsProvider
 
 
 @pytest.fixture
@@ -47,7 +48,7 @@ def node_output_info_data() -> dict:
 @pytest.fixture
 def node_info_data(
     node_input_info_data: dict, node_output_info_data: dict, node_id: str
-) -> dict:
+) -> dict[str, Any]:
     """
     Some data to define a NodeInfo object.
 

--- a/tests/test_node_info.py
+++ b/tests/test_node_info.py
@@ -1,4 +1,5 @@
-from typing import Optional
+from typing import Any, Optional
+from uuid import uuid4
 
 import pytest
 from pydantic import ValidationError
@@ -109,6 +110,17 @@ def test_node_info(node_info_data: dict):
     assert node_info.model_dump() == node_info_data
 
 
+def test_node_info_allows_extras(node_info_data: dict[str, Any]) -> None:
+    """
+    Adds an unexpected key to a serialised `NodeInfo` and expects the key to be
+    present in the deserialised model.
+    """
+
+    node_info_data[str(uuid4())] = "foo"
+    node_info = NodeInfo(**node_info_data)
+    assert node_info.model_dump() == node_info_data
+
+
 @pytest.mark.parametrize(
     "field",
     [
@@ -148,6 +160,7 @@ def test_node_info_raise_missing(node_info_data: dict, field: str):
         ("load_balancer_url", None),
         ("queue_url", None),
         ("cache_url", None),
+        ("requirements", None),
         ("version_types_lib", __version__),
     ],
 )

--- a/uncertainty_engine_types/node_info.py
+++ b/uncertainty_engine_types/node_info.py
@@ -27,7 +27,17 @@ class NodeRequirementsInfo(BaseModel):
     timeout: int
 
 
-class NodeInfo(BaseModel):
+class NodeInfo(BaseModel, extra="allow"):
+    """
+    Node information.
+    """
+
+    # New properties must be added as optional. The Resource Service uses this
+    # model and must support Nodes that don't provide a full set of details.
+    #
+    # Likewise, the `extra="allow"` argument allows the Resource Service to
+    # deserialise `NodeInfo` models with properties added post-release.
+
     id: str
     label: str
     category: str
@@ -37,7 +47,11 @@ class NodeInfo(BaseModel):
     cost: int
     inputs: dict[str, NodeInputInfo]
     outputs: dict[str, NodeOutputInfo] = {}
-    requirements: NodeRequirementsInfo
+    requirements: Optional[NodeRequirementsInfo] = None
+    """
+    Deployment requirements.
+    """
+
     load_balancer_url: Optional[str] = None
     queue_url: Optional[str] = None
     cache_url: Optional[str] = None

--- a/uncertainty_engine_types/node_info.py
+++ b/uncertainty_engine_types/node_info.py
@@ -32,10 +32,10 @@ class NodeInfo(BaseModel, extra="allow"):
     Node information.
     """
 
-    # New properties must be added as optional. The Resource Service uses this
+    # New properties must be added as optional. The Node Registry uses this
     # model and must support Nodes that don't provide a full set of details.
     #
-    # Likewise, the `extra="allow"` argument allows the Resource Service to
+    # Likewise, the `extra="allow"` argument allows the Node Registry to
     # deserialise `NodeInfo` models with properties added post-release.
 
     id: str


### PR DESCRIPTION
- Update `NodeInfo.requirements` to be optional and add regression test.
- Update `NodeInfo` to allow extra keys and add regression test.