### PR TITLE
`NodeRequirementsInfo` import fix

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,8 +46,20 @@ def node_output_info_data() -> dict:
 
 
 @pytest.fixture
+def node_requirements_info_data() -> dict:
+    """
+    Some data to define a NodeRequirementsInfo object.
+    """
+
+    return {"cpu": 256, "gpu": True, "memory": 512, "timeout": 60}
+
+
+@pytest.fixture
 def node_info_data(
-    node_input_info_data: dict, node_output_info_data: dict, node_id: str
+    node_input_info_data: dict,
+    node_output_info_data: dict,
+    node_id: str,
+    node_requirements_info_data: dict,
 ) -> dict[str, Any]:
     """
     Some data to define a NodeInfo object.
@@ -56,6 +68,7 @@ def node_info_data(
         node_input_info_data: Some data to define a NodeInputInfo object
         node_output_info_data: Some data to define a NodeOutputInfo object
         node_id: A node id
+        node_requirements_info_data: Some data to define a NodeRequirementsInfo object
     """
 
     return {
@@ -68,7 +81,7 @@ def node_info_data(
         "cost": 10,
         "inputs": {"input_1": node_input_info_data},
         "outputs": {"output_1": node_output_info_data},
-        "requirements": {"cpu": 256, "gpu": True, "memory": 512, "timeout": 60},
+        "requirements": node_requirements_info_data,
         "load_balancer_url": "load_balancer_url",
         "queue_url": "queue_url",
         "cache_url": "cache_url",

--- a/tests/test_library_import.py
+++ b/tests/test_library_import.py
@@ -9,3 +9,11 @@ def test_import_my_library():
         import uncertainty_engine_types
     except ImportError as err:
         pytest.fail(f"Failed to import 'uncertainty_engine_types': {err}")
+
+
+def test_star_import():
+    """
+    Verify types that are imported with a star import.
+    """
+
+    exec("from uncertainty_engine_types import *")

--- a/tests/test_node_info.py
+++ b/tests/test_node_info.py
@@ -4,7 +4,12 @@ from uuid import uuid4
 import pytest
 from pydantic import ValidationError
 
-from uncertainty_engine_types import NodeInfo, NodeInputInfo, NodeOutputInfo
+from uncertainty_engine_types import (
+    NodeInfo,
+    NodeInputInfo,
+    NodeOutputInfo,
+    NodeRequirementsInfo,
+)
 from uncertainty_engine_types.version import __version__
 
 
@@ -181,3 +186,37 @@ def test_node_info_optional(node_info_data: dict, field: str, expected):
     node_info = NodeInfo(**node_info_data)
 
     assert node_info.model_dump()[field] == expected
+
+
+def test_node_requirements_info(node_requirements_info_data: dict):
+    """
+    Basic test that NodeRequirementsInfo model is working as expected.
+
+    Args:
+        node_requirements_info_data: Some data to define a NodeRequirementsInfo object
+    """
+
+    # Instantiate a NodeRequirementsInfo object
+    node_requirements_info = NodeRequirementsInfo(**node_requirements_info_data)
+
+    assert node_requirements_info.model_dump() == node_requirements_info_data
+
+
+@pytest.mark.parametrize("field", ["cpu", "gpu", "memory", "timeout"])
+def test_node_requirements_info_raise_missing(
+    node_requirements_info_data: dict, field: str
+):
+    """
+    Test that NodeRequirementsInfo object raises an error when missing a required field.
+
+    Args:
+        node_requirements_info_data: Some data to define a NodeRequirementsInfo object
+        field: A field to remove from the node_requirements_info_data
+    """
+
+    # Remove a required field
+    del node_requirements_info_data[field]
+
+    # Try to instantiate a NodeRequirementsInfo object with a missing required field
+    with pytest.raises(ValidationError):
+        NodeRequirementsInfo(**node_requirements_info_data)

--- a/tests/test_node_info.py
+++ b/tests/test_node_info.py
@@ -8,7 +8,7 @@ from uncertainty_engine_types import NodeInfo, NodeInputInfo, NodeOutputInfo
 from uncertainty_engine_types.version import __version__
 
 
-def test_machine_learning_model(node_input_info_data: dict):
+def test_node_input_info_model(node_input_info_data: dict):
     """
     Basic test that NodeInputInfo model is working as expected.
 
@@ -17,13 +17,13 @@ def test_machine_learning_model(node_input_info_data: dict):
     """
 
     # Instantiate a NodeInputInfo object
-    machine_learning_model = NodeInputInfo(**node_input_info_data)
+    node_input_info = NodeInputInfo(**node_input_info_data)
 
-    assert machine_learning_model.model_dump() == node_input_info_data
+    assert node_input_info.model_dump() == node_input_info_data
 
 
 @pytest.mark.parametrize("field", ["type", "label", "description"])
-def test_machine_learning_model_raise_missing(node_input_info_data: dict, field: str):
+def test_node_input_info_raise_missing(node_input_info_data: dict, field: str):
     """
     Test that NodeInputInfo object raises an error when missing a required field.
 

--- a/uncertainty_engine_types/__init__.py
+++ b/uncertainty_engine_types/__init__.py
@@ -25,7 +25,7 @@ from .llm import LLMConfig, LLMProvider
 from .message import Message
 from .model import MachineLearningModel
 from .model_config import ModelConfig
-from .node_info import NodeInfo, NodeInputInfo, NodeOutputInfo
+from .node_info import NodeInfo, NodeInputInfo, NodeOutputInfo, NodeRequirementsInfo
 from .prompt import Prompt
 from .sensor_designer import SensorDesigner
 from .sql import SQLConfig, SQLKind


### PR DESCRIPTION
This PR fixes a bug where `NodeRequirementsInfo` was added in `__all__` in the package level `__init__` but was never imported.

This PR also adds some tests for `NodeRequirementsInfo` and a test to ensure a package level star import works.