### PR TITLE
Adding default factory to message type

### DIFF
--- a/uncertainty_engine_types/message.py
+++ b/uncertainty_engine_types/message.py
@@ -1,13 +1,13 @@
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, field_validator, Field
 
 
 class Message(BaseModel):
     role: Literal["instruction", "user", "engine"]
     content: str
-    timestamp: datetime
+    timestamp: datetime = Field(default_factory=datetime.now)
 
     @field_validator("content", mode="before")
     @classmethod


### PR DESCRIPTION
This may be a bad idea so doesnt need to go in. Sometimes its annoying always have to pass a datetime; this sets the fault value for message to the time at creation of the instance.