### PR TITLE
`PB-945:` Bump types version to `0.9.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uncertainty-engine-types"
-version = "0.8.0"
+version = "0.9.0"
 description = "Common type definitions for the Uncertainty Engine"
 authors = [
     { name = "Freddy Wordingham", email = "freddy@digilab.ai" },


### PR DESCRIPTION
This PR bumps the version of types to `0.9.0`. This will allow other repos to use `Context` with the newly added `is_root` field.