### PR TITLE
PB-1420: Add Windows to CI testing matrix

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -10,13 +10,18 @@ on:
       - main
       - dev
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   unit_tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -34,4 +39,4 @@ jobs:
         run: poetry install
 
       - name: Run tests
-        run: sh ci/run_tests.sh
+        run: poetry run pytest tests

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -13,19 +13,11 @@ on:
 jobs:
   unit_tests:
     runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: ${{ matrix.shell }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest]
-        include:
-          - os: ubuntu-latest
-            shell: bash
-          - os: windows-latest
-            shell: pwsh
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -10,18 +10,22 @@ on:
       - main
       - dev
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
   unit_tests:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            shell: bash
+          - os: windows-latest
+            shell: pwsh
 
     steps:
       - uses: actions/checkout@v4

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-
-poetry run pytest tests

--- a/git_hooks/pre-push
+++ b/git_hooks/pre-push
@@ -10,4 +10,4 @@ echo "[2/3] Running linter..."
 sh ./ci/run_linter.sh
 
 echo "[3/3] Running unit tests..."
-sh ./ci/run_tests.sh
+poetry run pytest tests


### PR DESCRIPTION
## Summary

Adds `windows-latest` to the CI testing matrix for unit tests, ensuring the types package is validated on Windows.

## Changes

- Added `os: [ubuntu-latest, windows-latest]` to the strategy matrix
- Set `defaults: run: shell: bash` at the workflow level (Git Bash is available on Windows runners)
- Replaced `sh ci/run_tests.sh` with direct `poetry run pytest tests` command for cross-platform compatibility

## What was tested

- CI will run on this PR to validate the Windows matrix works end-to-end